### PR TITLE
Configure Vite build settings: increase chunk size warning limit to 2…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,15 +5,16 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  build: {
+    chunkSizeWarningLimit: 2000, // size in KB
+  },
   server: {
     host: "::",
     port: 8080,
   },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
+  plugins: [react(), mode === "development" && componentTagger()].filter(
+    Boolean
+  ),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
…000 KB and streamline plugin array formatting.